### PR TITLE
Rename default base URL to api.pinax.network

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "prepublishOnly": "bun run build",
-    "generate": "openapi-typescript https://token-api.stage.pinax.network/openapi -o src/openapi.d.ts",
+    "generate": "openapi-typescript https://api.pinax.network/openapi -o src/openapi.d.ts",
     "build": "bun run generate && bun build src/index.ts --outdir dist --target node && bun run build:types",
     "build:types": "tsc --emitDeclarationOnly --declaration --outDir dist && cp ./src/openapi.d.ts dist/openapi.d.ts",
     "typecheck": "tsc --noEmit",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -228,7 +228,7 @@ describe('TokenAPI', () => {
 
 describe('Constants', () => {
   it('should export DEFAULT_BASE_URL', () => {
-    expect(DEFAULT_BASE_URL).toBe('https://token-api.thegraph.com');
+    expect(DEFAULT_BASE_URL).toBe('https://api.pinax.network');
   });
 
   describe('EVMChains', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import type { paths } from './openapi.d.ts';
 export type * from './openapi.d.ts';
 
 // Constants
-export const DEFAULT_BASE_URL = 'https://token-api.thegraph.com';
+export const DEFAULT_BASE_URL = 'https://api.pinax.network';
 
 /**
  * Typed error class for API-level errors returned by the Token API.


### PR DESCRIPTION
## Summary
- Token API moved to `https://api.pinax.network`.
- Update `DEFAULT_BASE_URL`, `generate` script source, and test expectation.
- Regenerated `src/openapi.d.ts` from new endpoint (no schema diff vs. previous stage source).

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` — 111 pass
- [ ] Smoke-test against `https://api.pinax.network` from an example before publishing release

🤖 Generated with [Claude Code](https://claude.com/claude-code)