### PR TITLE
Rename to @pinax/api (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
-# Token API `@pinax/token-api`
+# Pinax API `@pinax/api`
 
-> Power your apps & AI agents with real-time token data.
+> Power your apps & AI agents with real-time blockchain data.
 
-[![npm version](https://img.shields.io/npm/v/@pinax/token-api.svg)](https://www.npmjs.com/package/@pinax/token-api)
+[![npm version](https://img.shields.io/npm/v/@pinax/api.svg)](https://www.npmjs.com/package/@pinax/api)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Overview
 
-The `@pinax/token-api` provides a type-safe TypeScript client for [The Graph's Token API](https://thegraph.com/docs/en/token-api/quick-start/). Access blockchain token information including:
+The `@pinax/api` provides a type-safe TypeScript client for the [Pinax API](https://docs.pinax.network). Access blockchain data including:
 
-- **Token Transfers** - ERC-20 and native token transfers
-- **DEX Swaps** - Uniswap and other DEX swap events
+- **Token Transfers** - ERC-20, SPL, TRC-20 and native token transfers
+- **DEX Swaps** - Uniswap, Jupiter, Raydium and other DEX swap events
 - **Token Metadata** - Symbol, name, decimals, supply
 - **Balances** - Real-time token holdings
 - **Prices** - Current USD prices and OHLCV data
 - **Liquidity Pools** - DEX pool information
+- **NFTs** - Collections, holders, items, sales, transfers
+- **Polymarket** - Markets, activity, positions, users
+- **Hyperliquid** - Markets, users, vaults, liquidations
 
 ### Supported Networks
 
@@ -29,25 +32,25 @@ The SDK provides typed chain constants for type-safe network selection:
 ### Installation
 
 ```bash
-npm install @pinax/token-api
+npm install @pinax/api
 ```
 
 ### Authentication
 
-Get your API key from [The Graph Market](https://thegraph.market).
+Get your API key from [pinax.network](https://pinax.network).
 
 ```typescript
-const client = new TokenAPI({
-  apiToken: "YOUR_API_KEY_HERE" // or set TOKENAPI_KEY in your environment
+const client = new PinaxAPI({
+  apiToken: "YOUR_API_KEY_HERE" // or set PINAX_API_KEY in your environment
 });
 ```
 
 ### Basic Usage
 
 ```typescript
-import { TokenAPI, EVMChains } from "@pinax/token-api";
+import { PinaxAPI, EVMChains } from "@pinax/api";
 
-const client = new TokenAPI({
+const client = new PinaxAPI({
   apiToken: "YOUR_API_KEY_HERE"
 });
 
@@ -144,9 +147,8 @@ bun run build
 
 ## Related Resources
 
-- [Token API Documentation](https://thegraph.com/docs/en/token-api/quick-start/)
-- [The Graph Market](https://thegraph.market) - Get your API key
-- [Token API Repository](https://github.com/pinax-network/token-api)
+- [Pinax API Documentation](https://docs.pinax.network)
+- [Pinax](https://pinax.network) - Get your API key
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Token API Examples
 
-This folder contains TypeScript examples demonstrating how to use the `@pinax/token-api` to access blockchain token data.
+This folder contains TypeScript examples demonstrating how to use the `@pinax/api` to access blockchain token data.
 
 ## Prerequisites
 

--- a/examples/auto-pagination.ts
+++ b/examples/auto-pagination.ts
@@ -4,18 +4,18 @@
  * This example retrieves USDT (TRC-20) transfers on the Tron network.
  * USDT Contract on Tron: TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t
  *
- * @see https://thegraph.com/docs/en/token-api/quick-start/
+ * @see https://docs.pinax.network
  */
 
-import { TokenAPI } from '@pinax/token-api';
+import { PinaxAPI } from '@pinax/api';
 
 // USDT Token Contract Address on Tron Network
 const TRON_USDT_CONTRACT = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
 
 async function main() {
   // Initialize the client with your bearer token
-  const client = new TokenAPI({
-    apiToken: process.env.TOKENAPI_KEY,
+  const client = new PinaxAPI({
+    apiToken: process.env.PINAX_API_KEY,
   });
 
   console.log('Auto-pagination: Fetching USDT transfers on Tron network...\n');

--- a/examples/evm-ohlc.ts
+++ b/examples/evm-ohlc.ts
@@ -6,18 +6,18 @@
  *
  * Pool Contract: 0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36 (USDT/ETH Uniswap V3)
  *
- * @see https://thegraph.com/docs/en/token-api/quick-start/
+ * @see https://docs.pinax.network
  */
 
-import { TokenAPI } from '@pinax/token-api';
+import { PinaxAPI } from '@pinax/api';
 
 // USDT/ETH Uniswap V3 Pool Contract Address
 const USDT_ETH_POOL = '0x4e68Ccd3E89f51C3074ca5072bbAC773960dFa36';
 
 async function main() {
   // Initialize the client with your bearer token
-  const client = new TokenAPI({
-    apiToken: process.env.TOKENAPI_KEY,
+  const client = new PinaxAPI({
+    apiToken: process.env.PINAX_API_KEY,
   });
 
   console.log('Fetching OHLC data for USDT/ETH Uniswap V3 pool...\n');

--- a/examples/evm-usdc-holders.ts
+++ b/examples/evm-usdc-holders.ts
@@ -4,18 +4,18 @@
  * This example retrieves the top holders of the USDC token on Ethereum mainnet.
  * USDC Contract: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
  *
- * @see https://thegraph.com/docs/en/token-api/quick-start/
+ * @see https://docs.pinax.network
  */
 
-import { TokenAPI } from '@pinax/token-api';
+import { PinaxAPI } from '@pinax/api';
 
 // USDC Token Contract Address on Ethereum Mainnet
 const USDC_CONTRACT = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 
 async function main() {
   // Initialize the client with your bearer token
-  const client = new TokenAPI({
-    apiToken: process.env.TOKENAPI_KEY,
+  const client = new PinaxAPI({
+    apiToken: process.env.PINAX_API_KEY,
   });
 
   console.log('Fetching top USDC holders on Ethereum mainnet...\n');

--- a/examples/solana-swaps.ts
+++ b/examples/solana-swaps.ts
@@ -3,15 +3,15 @@
  *
  * This example retrieves the 100 most recent swap transactions on Solana.
  *
- * @see https://thegraph.com/docs/en/token-api/quick-start/
+ * @see https://docs.pinax.network
  */
 
-import { TokenAPI } from '@pinax/token-api';
+import { PinaxAPI } from '@pinax/api';
 
 async function main() {
   // Initialize the client with your bearer token
-  const client = new TokenAPI({
-    apiToken: process.env.TOKENAPI_KEY,
+  const client = new PinaxAPI({
+    apiToken: process.env.PINAX_API_KEY,
   });
 
   console.log('Fetching 100 most recent swaps on Solana...\n');

--- a/examples/tron-usdt-transfers.ts
+++ b/examples/tron-usdt-transfers.ts
@@ -4,18 +4,18 @@
  * This example retrieves USDT (TRC-20) transfers on the Tron network.
  * USDT Contract on Tron: TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t
  *
- * @see https://thegraph.com/docs/en/token-api/quick-start/
+ * @see https://docs.pinax.network
  */
 
-import { TokenAPI } from '@pinax/token-api';
+import { PinaxAPI } from '@pinax/api';
 
 // USDT Token Contract Address on Tron Network
 const TRON_USDT_CONTRACT = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
 
 async function main() {
   // Initialize the client with your bearer token
-  const client = new TokenAPI({
-    apiToken: process.env.TOKENAPI_KEY,
+  const client = new PinaxAPI({
+    apiToken: process.env.PINAX_API_KEY,
   });
 
   console.log('Fetching USDT transfers on Tron network...\n');

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "noEmit": true,
     "paths": {
-      "@pinax/token-api": ["../dist"]
+      "@pinax/api": ["../dist"]
     }
   },
   "include": ["./*.ts"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@pinax/token-api",
-  "version": "0.2.12",
-  "description": "Pinax Token API - Power your apps & AI agents with real-time token data",
+  "name": "@pinax/api",
+  "version": "0.3.0",
+  "description": "Pinax API - Power your apps & AI agents with real-time blockchain data",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,10 +29,12 @@
   },
   "keywords": [
     "pinax",
-    "token-api",
+    "api",
     "blockchain",
     "evm",
     "ethereum",
+    "solana",
+    "tron",
     "sdk"
   ],
   "license": "Apache-2.0",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,12 +1,12 @@
 /**
- * Token API Client Tests
+ * Pinax API Client Tests
  *
- * Unit tests for the @pinax/token-api SDK using Bun Test runner.
+ * Unit tests for the @pinax/api SDK using Bun Test runner.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import {
-  TokenAPI,
+  PinaxAPI,
   APIError,
   createAPIClient,
   DEFAULT_BASE_URL,
@@ -35,11 +35,11 @@ describe('createAPIClient', () => {
   });
 });
 
-describe('TokenAPI', () => {
+describe('PinaxAPI', () => {
   describe('constructor', () => {
-    it('should create a TokenAPI instance with default options', () => {
-      const client = new TokenAPI();
-      expect(client).toBeInstanceOf(TokenAPI);
+    it('should create a PinaxAPI instance with default options', () => {
+      const client = new PinaxAPI();
+      expect(client).toBeInstanceOf(PinaxAPI);
       expect(client.evm).toBeDefined();
       expect(client.svm).toBeDefined();
       expect(client.tvm).toBeDefined();
@@ -47,16 +47,16 @@ describe('TokenAPI', () => {
       expect(client.hyperliquid).toBeDefined();
     });
 
-    it('should create a TokenAPI instance with custom options', () => {
-      const client = new TokenAPI({
+    it('should create a PinaxAPI instance with custom options', () => {
+      const client = new PinaxAPI({
         apiToken: 'test-token',
         baseUrl: 'https://custom.example.com',
       });
-      expect(client).toBeInstanceOf(TokenAPI);
+      expect(client).toBeInstanceOf(PinaxAPI);
     });
 
     it('should expose getClient method', () => {
-      const client = new TokenAPI();
+      const client = new PinaxAPI();
       const internalClient = client.getClient();
       expect(internalClient).toBeDefined();
       expect(typeof internalClient.GET).toBe('function');
@@ -64,10 +64,10 @@ describe('TokenAPI', () => {
   });
 
   describe('EVM API structure', () => {
-    let client: TokenAPI;
+    let client: PinaxAPI;
 
     beforeEach(() => {
-      client = new TokenAPI();
+      client = new PinaxAPI();
     });
 
     it('should expose evm.tokens API', () => {
@@ -100,10 +100,10 @@ describe('TokenAPI', () => {
   });
 
   describe('SVM API structure', () => {
-    let client: TokenAPI;
+    let client: PinaxAPI;
 
     beforeEach(() => {
-      client = new TokenAPI();
+      client = new PinaxAPI();
     });
 
     it('should expose svm.tokens API', () => {
@@ -133,10 +133,10 @@ describe('TokenAPI', () => {
   });
 
   describe('TVM API structure', () => {
-    let client: TokenAPI;
+    let client: PinaxAPI;
 
     beforeEach(() => {
-      client = new TokenAPI();
+      client = new PinaxAPI();
     });
 
     it('should expose tvm.tokens API', () => {
@@ -161,10 +161,10 @@ describe('TokenAPI', () => {
   });
 
   describe('System methods', () => {
-    let client: TokenAPI;
+    let client: PinaxAPI;
 
     beforeEach(() => {
-      client = new TokenAPI();
+      client = new PinaxAPI();
     });
 
     it('should expose getHealth method', () => {
@@ -181,10 +181,10 @@ describe('TokenAPI', () => {
   });
 
   describe('Polymarket API structure', () => {
-    let client: TokenAPI;
+    let client: PinaxAPI;
 
     beforeEach(() => {
-      client = new TokenAPI();
+      client = new PinaxAPI();
     });
 
     it('should expose polymarket API', () => {
@@ -201,10 +201,10 @@ describe('TokenAPI', () => {
   });
 
   describe('Hyperliquid API structure', () => {
-    let client: TokenAPI;
+    let client: PinaxAPI;
 
     beforeEach(() => {
-      client = new TokenAPI();
+      client = new PinaxAPI();
     });
 
     it('should expose hyperliquid API', () => {
@@ -306,7 +306,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM transfers', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getTransfers({
       network: 'mainnet',
@@ -319,7 +319,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM swaps', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.dexs.getSwaps({
       network: 'mainnet',
@@ -332,7 +332,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should include protocol filter for EVM pools', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.dexs.getPools({
       network: 'mainnet',
@@ -345,7 +345,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM transfers', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getTransfers({
       network: 'solana',
@@ -358,7 +358,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM native transfers', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getNativeTransfers({
       network: 'solana',
@@ -371,7 +371,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should include amm_pool filter for SVM pools', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.dexs.getPools({
       network: 'solana',
@@ -384,7 +384,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for TVM transfers', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.tokens.getTransfers({
       network: 'tron',
@@ -397,7 +397,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should include protocol filter for TVM pools', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.dexs.getPools({
       network: 'tron',
@@ -410,7 +410,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should work with EVMChains.Ethereum constant', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getTransfers({
       network: EVMChains.Ethereum,
@@ -423,7 +423,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should work with SVMChains.Solana constant', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getTransfers({
       network: SVMChains.Solana,
@@ -436,7 +436,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should work with TVMChains.Tron constant', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.tokens.getTransfers({
       network: TVMChains.Tron,
@@ -449,7 +449,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should include authorization header when API token is provided', async () => {
-    const client = new TokenAPI({ apiToken: 'my-test-token' });
+    const client = new PinaxAPI({ apiToken: 'my-test-token' });
 
     await client.evm.tokens.getTransfers({
       network: 'mainnet',
@@ -463,7 +463,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should include referrer header in all requests', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getTransfers({
       network: 'mainnet',
@@ -471,12 +471,12 @@ describe('API methods with mocked fetch', () => {
     });
 
     expect(capturedRequest).not.toBeNull();
-    expect(capturedRequest!.headers.get('User-Agent')).toBe('@pinax/token-api');
+    expect(capturedRequest!.headers.get('User-Agent')).toBe('@pinax/api');
   });
 
   it('should use custom base URL when provided', async () => {
     const customUrl = 'https://custom-api.example.com';
-    const client = new TokenAPI({
+    const client = new PinaxAPI({
       apiToken: 'test-token',
       baseUrl: customUrl,
     });
@@ -491,7 +491,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call health endpoint', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.getHealth();
 
@@ -500,7 +500,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call version endpoint', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.getVersion();
 
@@ -509,7 +509,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call networks endpoint', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.getNetworks();
 
@@ -518,7 +518,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call networks endpoint with filter', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.getNetworks({ network: 'mainnet' });
 
@@ -530,7 +530,7 @@ describe('API methods with mocked fetch', () => {
   // --- EVM Tokens: uncovered methods ---
 
   it('should call the correct endpoint for EVM native transfers', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getNativeTransfers({
       network: 'mainnet',
@@ -543,7 +543,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getTokenMetadata({
       network: 'mainnet',
@@ -556,7 +556,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should support array of contracts for EVM token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getTokenMetadata({
       network: 'mainnet',
@@ -568,7 +568,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM balances', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getBalances({
       network: 'mainnet',
@@ -581,7 +581,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM holders', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getHolders({
       network: 'mainnet',
@@ -594,7 +594,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM native holders', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getNativeHolders({
       network: 'mainnet',
@@ -605,7 +605,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM native balances', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getNativeBalances({
       network: 'mainnet',
@@ -617,7 +617,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM historical balances', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getHistoricalBalances({
       network: 'mainnet',
@@ -631,7 +631,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM historical native balances', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getHistoricalNativeBalances({
       network: 'mainnet',
@@ -644,7 +644,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM native token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.tokens.getNativeTokenMetadata({
       network: 'mainnet',
@@ -657,7 +657,7 @@ describe('API methods with mocked fetch', () => {
   // --- EVM DEXs: uncovered methods ---
 
   it('should call the correct endpoint for EVM dexes', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.dexs.getDexes({
       network: 'mainnet',
@@ -668,7 +668,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for EVM pool OHLC', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.dexs.getPoolOHLC({
       network: 'mainnet',
@@ -685,7 +685,7 @@ describe('API methods with mocked fetch', () => {
   // --- EVM NFTs: all methods ---
 
   it('should call the correct endpoint for NFT collections', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.nfts.getCollections({
       network: 'mainnet',
@@ -698,7 +698,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for NFT holders', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.nfts.getHolders({
       network: 'mainnet',
@@ -710,7 +710,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for NFT items', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.nfts.getItems({
       network: 'mainnet',
@@ -724,7 +724,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for NFT ownerships', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.nfts.getOwnerships({
       network: 'mainnet',
@@ -737,7 +737,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should include new params for NFT ownerships', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.nfts.getOwnerships({
       network: 'mainnet',
@@ -752,7 +752,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for NFT sales', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.nfts.getSales({
       network: 'mainnet',
@@ -764,7 +764,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for NFT transfers', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.nfts.getTransfers({
       network: 'mainnet',
@@ -776,7 +776,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should include type and address params for NFT transfers', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.evm.nfts.getTransfers({
       network: 'mainnet',
@@ -793,7 +793,7 @@ describe('API methods with mocked fetch', () => {
   // --- SVM Tokens: uncovered methods ---
 
   it('should call the correct endpoint for SVM token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getTokenMetadata({
       network: 'solana',
@@ -806,7 +806,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should support array of mints for SVM token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getTokenMetadata({
       network: 'solana',
@@ -818,7 +818,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM native token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getNativeTokenMetadata({
       network: 'solana',
@@ -830,7 +830,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM balances', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getBalances({
       network: 'solana',
@@ -843,7 +843,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM native balances', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getNativeBalances({
       network: 'solana',
@@ -855,7 +855,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM holders', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getHolders({
       network: 'solana',
@@ -868,7 +868,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM native holders', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getNativeHolders({
       network: 'solana',
@@ -881,7 +881,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM account owner', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.tokens.getAccountOwner({
       network: 'solana',
@@ -896,7 +896,7 @@ describe('API methods with mocked fetch', () => {
   // --- SVM DEXs: uncovered methods ---
 
   it('should call the correct endpoint for SVM swaps', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.dexs.getSwaps({
       network: 'solana',
@@ -908,7 +908,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM dexes', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.dexs.getDexes({
       network: 'solana',
@@ -919,7 +919,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for SVM pool OHLC', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.svm.dexs.getPoolOHLC({
       network: 'solana',
@@ -935,7 +935,7 @@ describe('API methods with mocked fetch', () => {
   // --- TVM Tokens: uncovered methods ---
 
   it('should call the correct endpoint for TVM native transfers', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.tokens.getNativeTransfers({
       network: 'tron',
@@ -947,7 +947,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for TVM token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.tokens.getTokenMetadata({
       network: 'tron',
@@ -960,7 +960,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should support array of contracts for TVM token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.tokens.getTokenMetadata({
       network: 'tron',
@@ -972,7 +972,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for TVM native token metadata', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.tokens.getNativeTokenMetadata({
       network: 'tron',
@@ -985,7 +985,7 @@ describe('API methods with mocked fetch', () => {
   // --- TVM DEXs: uncovered methods ---
 
   it('should call the correct endpoint for TVM swaps', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.dexs.getSwaps({
       network: 'tron',
@@ -997,7 +997,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for TVM dexes', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.dexs.getDexes({
       network: 'tron',
@@ -1008,7 +1008,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for TVM pool OHLC', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.tvm.dexs.getPoolOHLC({
       network: 'tron',
@@ -1024,7 +1024,7 @@ describe('API methods with mocked fetch', () => {
   // --- Polymarket: all methods ---
 
   it('should call the correct endpoint for Polymarket markets', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.polymarket.getMarkets({
       market_slug: 'will-btc-hit-100k',
@@ -1036,7 +1036,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Polymarket market OHLC', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.polymarket.getMarketOHLC({
       token_id: '123',
@@ -1050,7 +1050,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Polymarket open interest', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.polymarket.getMarketOpenInterest({
       market_slug: 'will-btc-hit-100k',
@@ -1063,7 +1063,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Polymarket activity', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.polymarket.getMarketActivity({
       user: '0xabc',
@@ -1077,7 +1077,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Polymarket market positions', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.polymarket.getMarketPositions({
       token_id: '123',
@@ -1090,7 +1090,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Polymarket platform aggregates', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.polymarket.getPlatform({
       interval: '1d',
@@ -1102,7 +1102,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Polymarket users', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.polymarket.getUsers({
       interval: '30d',
@@ -1116,7 +1116,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Polymarket user positions', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.polymarket.getUserPositions({
       user: '0xabc',
@@ -1132,7 +1132,7 @@ describe('API methods with mocked fetch', () => {
   // --- Hyperliquid: all methods ---
 
   it('should call the correct endpoint for Hyperliquid dexes', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getDexes();
 
@@ -1141,7 +1141,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid markets', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getMarkets({
       base_token: 'HYPE',
@@ -1155,7 +1155,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid market OHLC', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getMarketOHLC({
       coin: 'BTC',
@@ -1169,7 +1169,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid market open interest', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getMarketOpenInterest({
       coin: 'BTC',
@@ -1182,7 +1182,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid market activity', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getMarketActivity({
       coin: 'BTC',
@@ -1196,7 +1196,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid liquidations', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getLiquidations({
       coin: 'BTC',
@@ -1209,7 +1209,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid liquidation OHLC', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getLiquidationOHLC({
       coin: 'BTC',
@@ -1223,7 +1223,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid users', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getUsers({
       user: '0xabc',
@@ -1237,7 +1237,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid user positions', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getUserPositions({
       user: '0xabc',
@@ -1251,7 +1251,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid user activity', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getUserActivity({
       user: '0xabc',
@@ -1265,7 +1265,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid vaults', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getVaults({
       vault: '0xvault',
@@ -1277,7 +1277,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid vault depositors', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getVaultDepositors({
       vault: '0xvault',
@@ -1289,7 +1289,7 @@ describe('API methods with mocked fetch', () => {
   });
 
   it('should call the correct endpoint for Hyperliquid platform aggregates', async () => {
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await client.hyperliquid.getPlatform({
       interval: '1d',
@@ -1329,7 +1329,7 @@ describe('Error handling', () => {
       );
     }) as typeof fetch;
 
-    const client = new TokenAPI({ apiToken: 'invalid-token' });
+    const client = new PinaxAPI({ apiToken: 'invalid-token' });
 
     try {
       await client.evm.tokens.getTransfers({ network: 'mainnet' });
@@ -1360,7 +1360,7 @@ describe('Error handling', () => {
       );
     }) as typeof fetch;
 
-    const client = new TokenAPI({ apiToken: 'invalid-token' });
+    const client = new PinaxAPI({ apiToken: 'invalid-token' });
 
     await expect(
       client.evm.tokens.getTransfers({ network: 'mainnet' }),
@@ -1377,7 +1377,7 @@ describe('Error handling', () => {
       );
     }) as typeof fetch;
 
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     await expect(
       client.evm.tokens.getTransfers({ network: 'mainnet' }),
@@ -1401,7 +1401,7 @@ describe('Error handling', () => {
       );
     }) as typeof fetch;
 
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     try {
       await client.evm.tokens.getTransfers({ network: 'mainnet' });
@@ -1430,7 +1430,7 @@ describe('Error handling', () => {
       );
     }) as typeof fetch;
 
-    const client = new TokenAPI({ apiToken: 'test-token' });
+    const client = new PinaxAPI({ apiToken: 'test-token' });
 
     try {
       await client.evm.tokens.getTransfers({ network: 'mainnet' });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * @pinax/token-api - Pinax Token API
+ * @pinax/api - Pinax API
  *
- * Power your apps & AI agents with real-time token data.
+ * Power your apps & AI agents with real-time blockchain data.
  *
- * @see https://thegraph.com/docs/en/token-api/quick-start/
+ * @see https://docs.pinax.network
  * @license Apache-2.0
  */
 
@@ -17,7 +17,7 @@ export type * from './openapi.d.ts';
 export const DEFAULT_BASE_URL = 'https://api.pinax.network';
 
 /**
- * Typed error class for API-level errors returned by the Token API.
+ * Typed error class for API-level errors returned by the Pinax API.
  *
  * Network errors (DNS, socket, timeout) propagate as native `TypeError`/`Error`
  * and do not go through `handleResponse`, so they are not wrapped in `APIError`.
@@ -47,27 +47,27 @@ export class APIError extends Error {
 }
 
 // Response types inferred from operations
-export type EvmTransfersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['evm']['tokens']['getTransfers']>>>;
-export type EvmSwapsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['evm']['dexs']['getSwaps']>>>;
-export type EvmTokensResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['evm']['tokens']['getTokenMetadata']>>>;
-export type EvmBalancesResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['evm']['tokens']['getBalances']>>>;
-export type EvmHoldersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['evm']['tokens']['getHolders']>>>;
-export type EvmPoolsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['evm']['dexs']['getPools']>>>;
-export type SvmTransfersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['svm']['tokens']['getTransfers']>>>;
-export type SvmSwapsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['svm']['dexs']['getSwaps']>>>;
-export type SvmTokensResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['svm']['tokens']['getTokenMetadata']>>>;
-export type SvmNativeTokensResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['svm']['tokens']['getNativeTokenMetadata']>>>;
-export type SvmBalancesResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['svm']['tokens']['getBalances']>>>;
-export type SvmHoldersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['svm']['tokens']['getHolders']>>>;
-export type SvmPoolsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['svm']['dexs']['getPools']>>>;
-export type TvmTransfersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['tvm']['tokens']['getTransfers']>>>;
-export type TvmSwapsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['tvm']['dexs']['getSwaps']>>>;
-export type TvmTokensResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['tvm']['tokens']['getTokenMetadata']>>>;
-export type TvmPoolsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['tvm']['dexs']['getPools']>>>;
-export type PolymarketMarketsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['polymarket']['getMarkets']>>>;
-export type PolymarketUsersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['polymarket']['getUsers']>>>;
-export type HyperliquidMarketsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['hyperliquid']['getMarkets']>>>;
-export type HyperliquidUsersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof TokenAPI>['hyperliquid']['getUsers']>>>;
+export type EvmTransfersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['evm']['tokens']['getTransfers']>>>;
+export type EvmSwapsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['evm']['dexs']['getSwaps']>>>;
+export type EvmTokensResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['evm']['tokens']['getTokenMetadata']>>>;
+export type EvmBalancesResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['evm']['tokens']['getBalances']>>>;
+export type EvmHoldersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['evm']['tokens']['getHolders']>>>;
+export type EvmPoolsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['evm']['dexs']['getPools']>>>;
+export type SvmTransfersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['svm']['tokens']['getTransfers']>>>;
+export type SvmSwapsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['svm']['dexs']['getSwaps']>>>;
+export type SvmTokensResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['svm']['tokens']['getTokenMetadata']>>>;
+export type SvmNativeTokensResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['svm']['tokens']['getNativeTokenMetadata']>>>;
+export type SvmBalancesResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['svm']['tokens']['getBalances']>>>;
+export type SvmHoldersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['svm']['tokens']['getHolders']>>>;
+export type SvmPoolsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['svm']['dexs']['getPools']>>>;
+export type TvmTransfersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['tvm']['tokens']['getTransfers']>>>;
+export type TvmSwapsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['tvm']['dexs']['getSwaps']>>>;
+export type TvmTokensResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['tvm']['tokens']['getTokenMetadata']>>>;
+export type TvmPoolsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['tvm']['dexs']['getPools']>>>;
+export type PolymarketMarketsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['polymarket']['getMarkets']>>>;
+export type PolymarketUsersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['polymarket']['getUsers']>>>;
+export type HyperliquidMarketsResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['hyperliquid']['getMarkets']>>>;
+export type HyperliquidUsersResponse = NonNullable<Awaited<ReturnType<InstanceType<typeof PinaxAPI>['hyperliquid']['getUsers']>>>;
 
 type GetQuery<P extends keyof paths> = paths[P] extends {
   get: {
@@ -140,9 +140,9 @@ export type DexProtocol = EvmDexProtocol;
  *
  * @example
  * ```typescript
- * import { TokenAPI, EVMChains } from "@pinax/token-api";
+ * import { PinaxAPI, EVMChains } from "@pinax/api";
  *
- * const client = new TokenAPI();
+ * const client = new PinaxAPI();
  * const transfers = await client.evm.tokens.getTransfers({
  *   network: EVMChains.Ethereum,
  *   limit: 10,
@@ -174,9 +174,9 @@ export const EVMChains = {
  *
  * @example
  * ```typescript
- * import { TokenAPI, SVMChains } from "@pinax/token-api";
+ * import { PinaxAPI, SVMChains } from "@pinax/api";
  *
- * const client = new TokenAPI();
+ * const client = new PinaxAPI();
  * const transfers = await client.svm.tokens.getTransfers({
  *   network: SVMChains.Solana,
  *   limit: 10,
@@ -194,9 +194,9 @@ export const SVMChains = {
  *
  * @example
  * ```typescript
- * import { TokenAPI, TVMChains } from "@pinax/token-api";
+ * import { PinaxAPI, TVMChains } from "@pinax/api";
  *
- * const client = new TokenAPI();
+ * const client = new PinaxAPI();
  * const transfers = await client.tvm.tokens.getTransfers({
  *   network: TVMChains.Tron,
  *   limit: 10,
@@ -243,18 +243,18 @@ function createAuthMiddleware(options: PinaxClientOptions): Middleware {
       if (apiToken) {
         request.headers.set('Authorization', `Bearer ${apiToken}`);
       }
-      request.headers.set('User-Agent', '@pinax/token-api');
+      request.headers.set('User-Agent', '@pinax/api');
       return request;
     },
   };
 }
 
 /**
- * Create a Pinax Token API client for accessing the Token API
+ * Create a Pinax API client
  *
  * @example
  * ```typescript
- * import { createAPIClient } from "@pinax/token-api";
+ * import { createAPIClient } from "@pinax/api";
  *
  * const client = createAPIClient({
  *   apiToken: "your-api-token-jwt"
@@ -976,7 +976,7 @@ class SvmDexs {
  *
  * @remarks
  * This class is a placeholder for future NFT functionality on SVM networks (Solana).
- * Methods will be added when the Token API adds support for Solana NFT operations.
+ * Methods will be added when the Pinax API adds support for Solana NFT operations.
  */
 class SvmNfts {
   constructor(private client: ReturnType<typeof createAPIClient>) { }
@@ -1413,7 +1413,7 @@ class TvmDexs {
  *
  * @remarks
  * This class is a placeholder for future NFT functionality on TVM networks (Tron).
- * Methods will be added when the Token API adds support for Tron NFT operations.
+ * Methods will be added when the Pinax API adds support for Tron NFT operations.
  */
 class TvmNfts {
   constructor(private client: ReturnType<typeof createAPIClient>) { }
@@ -1435,13 +1435,13 @@ class TvmApi {
 }
 
 /**
- * High-level wrapper for common Token API operations
+ * High-level wrapper for common Pinax API operations
  *
  * @example
  * ```typescript
- * import { TokenAPI } from "@pinax/token-api";
+ * import { PinaxAPI } from "@pinax/api";
  *
- * const client = new TokenAPI({ apiToken: "YOUR_API_KEY_HERE" });
+ * const client = new PinaxAPI({ apiToken: "YOUR_API_KEY_HERE" });
  *
  * // Get EVM transfers
  * const transfers = await client.evm.tokens.getTransfers({
@@ -1456,7 +1456,7 @@ class TvmApi {
  * });
  * ```
  */
-export class TokenAPI {
+export class PinaxAPI {
   private client: ReturnType<typeof createAPIClient>;
 
   /**
@@ -1535,9 +1535,14 @@ export class TokenAPI {
 }
 
 // Default export
-export default TokenAPI;
+export default PinaxAPI;
 
 /**
- * @deprecated Use `TokenAPI` instead. `TokenClient` is an alias kept for backward compatibility.
+ * @deprecated Use `PinaxAPI` instead. `TokenAPI` is an alias kept for backward compatibility.
  */
-export const TokenClient = TokenAPI;
+export const TokenAPI = PinaxAPI;
+
+/**
+ * @deprecated Use `PinaxAPI` instead. `TokenClient` is an alias kept for backward compatibility.
+ */
+export const TokenClient = PinaxAPI;


### PR DESCRIPTION
## Summary
- Rename package `@pinax/token-api` → `@pinax/api`
- Rename main class `TokenAPI` → `PinaxAPI` (kept `TokenAPI`/`TokenClient` as deprecated aliases for backward compat)
- Bump version to `v0.3.0`
- Env var `TOKENAPI_KEY` → `PINAX_API_KEY` in examples
- Update User-Agent header to `@pinax/api`
- Regenerated OpenAPI types from https://api.pinax.network/openapi
- Verified all 65 v1 routes from the OpenAPI spec are covered by the SDK (no missing routes)
- Updated README, examples, and doc comments to drop "Token API" branding

## Breaking changes
- Package name change requires consumers to install `@pinax/api`
- Class rename: prefer `PinaxAPI`; `TokenAPI` still works but is deprecated
- Env var convention: examples now read `PINAX_API_KEY` (old name no longer referenced)

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` — 111/111 pass
- [x] Diff of OpenAPI routes vs SDK `GET()` calls is empty
- [ ] Publish dry-run on npm before tagging release

🤖 Generated with [Claude Code](https://claude.com/claude-code)