### PR TITLE
Update repo URL to pinax-api-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ for (const balance of balances.data ?? []) {
 
 ```bash
 # Clone the repository
-git clone https://github.com/pinax-network/token-api-sdk.git
-cd token-api-sdk
+git clone https://github.com/pinax-network/pinax-api-sdk.git
+cd pinax-api-sdk
 
 # Install dependencies
 bun install

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pinax-network/token-api-sdk.git"
+    "url": "git+https://github.com/pinax-network/pinax-api-sdk.git"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.6",


### PR DESCRIPTION
## Summary
- Update repository URL in `package.json` from `token-api-sdk` to `pinax-api-sdk`
- Update clone instructions in README

Follow-up to #56 after repo rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)